### PR TITLE
Don't require gulp to be globally installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,13 @@ Learn to scaffold out a complete web application that uses a Kitura server to se
  cd MyReact
  ```
  
-8. Install the node packages:
+8. Install the node packages and run gulp:
 
  ```npm install```
  
   ![Install node dependencies](images/install-node-deps.png)
- 
-8. Run gulp:
-
-    ```
-    gulp
-    ```
     
-    ![Run gulp](images/run-gulp.png)
+  ![Run gulp](images/run-gulp.png)
     
 9. Build the Swift project (takes 2 minutes)
 
@@ -114,7 +108,7 @@ Learn to scaffold out a complete web application that uses a Kitura server to se
   render(<App/>, document.getElementById('app'));
   ```
   
-3. Re-run `gulp`
+3. Re-run `npm install`
 
 4. Refresh your browser
 


### PR DESCRIPTION
Use `npm install` instead, as it (somewhat counter-intuitively) runs the
locally installed gulp.

The image would have to be updated as well.

The other short-term fix is to require an `npm install -g gulp` before this step, but that seems odd as you're already installing `gulp` as a dependency, meaning you're requiring gulp to be installed twice.

---

Longer term, it's pretty weird to repurpose `npm install` to run `gulp`, I'd suggest doing:

```json
  "postinstall": "npm run gulp",
  "gulp": "gulp"
```

Then `gulp` is still run as part of the `npm install` (the `postinstall` run script gets run automatically after installing), but you can also just do `npm run gulp` to run it by itself.

You don't [need to use](https://github.ibm.com/arf/generator-web/blob/master/generators/app/templates/webpack/package-node-combined.json#L11) `./node_modules/.bin/gulp` as that directory is always added to the path by npm.